### PR TITLE
Remove second argument when calling isValid on each Validator

### DIFF
--- a/src/Distiller.php
+++ b/src/Distiller.php
@@ -206,7 +206,7 @@ class Distiller implements DistillerInterface
 
             // If everything is correct, jump to next field
             if (empty($validator) ||
-                $validator->isValid($value, $this->getRawData())) {
+                $validator->isValid($value)) {
                 continue;
             }
 


### PR DESCRIPTION
When calling the `isValid` method on each `Validator` in the `validate()` function, the request's raw data was being passed as a second argument. However, this behavior is not documented, no tests have been written  to support this feature and it could be removed in the future.